### PR TITLE
Fix SHA for v1.5.0

### DIFF
--- a/Formula/powerlevel10k.rb
+++ b/Formula/powerlevel10k.rb
@@ -2,7 +2,7 @@ class Powerlevel10k < Formula
   desc "A Zsh Theme"
   homepage "https://github.com/romkatv/powerlevel10k"
   url "https://github.com/romkatv/powerlevel10k/archive/v1.5.0.tar.gz"
-  sha256 "233d817229731d80076d0c8312fb0130bf2d3e4300de1b8265866e43abc87c3c"
+  sha256 "e2297f5c2f804c0a5eedf804296dc0e1dbbe5e9532b8cd3af276588d71e9121d"
 
   bottle :unneeded
 


### PR DESCRIPTION
I was trying to install powerlevel10k on a new Macbook and ran into this issue:

```
% brew install romkatv/powerlevel10k/powerlevel10k                                                                                                      
==> Installing powerlevel10k from romkatv/powerlevel10k
==> Downloading https://github.com/romkatv/powerlevel10k/archive/v1.5.0.tar.gz
==> Downloading from https://codeload.github.com/romkatv/powerlevel10k/tar.gz/v1.5.0
######################################################################## 100.0%
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: 233d817229731d80076d0c8312fb0130bf2d3e4300de1b8265866e43abc87c3c
  Actual: e2297f5c2f804c0a5eedf804296dc0e1dbbe5e9532b8cd3af276588d71e9121d
 Archive: /Users/myusername/Library/Caches/Homebrew/downloads/d401c5ea6152c8604343f29628d22aa2e06ef9a9e6d89887d0cdb88db10d9ec8--powerlevel10k-1.5.0.tar.gz
To retry an incomplete download, remove the file above.
```

I downloaded v1.5.0 from https://github.com/romkatv/powerlevel10k/archive/v1.5.0.tar.gz and checked the SHA256 myself to verify:

```
% openssl dgst -sha256 ~/Downloads/powerlevel10k-1.5.0.tar.gz 
SHA256(/Users/myusername/Downloads/powerlevel10k-1.5.0.tar.gz)= e2297f5c2f804c0a5eedf804296dc0e1dbbe5e9532b8cd3af276588d71e9121d
```

This PR updates the SHA to the correct value.