### PR TITLE
fix: No need to depend on zsh.

### DIFF
--- a/Formula/powerlevel10k.rb
+++ b/Formula/powerlevel10k.rb
@@ -4,7 +4,7 @@ class Powerlevel10k < Formula
   url "https://github.com/romkatv/powerlevel10k/archive/v1.14.6.tar.gz"
   sha256 "092d2d85da9dce5711ed8d7a0d0329ea7c3fe7bc81692251917f83be9c2969c3"
 
-  depends_on "zsh"
+  uses_from_macos "zsh"
 
   def install
     system 'make', 'pkg'


### PR DESCRIPTION
zsh can be declared as used from macos and avoid requiring zsh to be installed via brew.