### PR TITLE
feat(cask): add `font-powerlevel10k-meslo-lgs-nf`

### DIFF
--- a/Casks/font-powerlevel10k-meslo-lgs-nf.rb
+++ b/Casks/font-powerlevel10k-meslo-lgs-nf.rb
@@ -1,0 +1,19 @@
+cask "font-powerlevel10k-meslo-lgs-nf" do
+  version "2020.4.15"
+  sha256 "b237985878c5588443010f5e8cd3e9a5849c2f8ca6806d68f406bec2bab8bbaa"
+
+  url "https://github.com/thecesrom/powerlevel10k-media/releases/download/v#{version}/MesloLGS-NF.zip"
+  name "Meslo Nerd Font patched for Powerlevel10k"
+  desc "Released under Apache License, Version 2.0"
+  homepage "https://github.com/thecesrom/powerlevel10k-media"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "MesloLGS NF Bold Italic.ttf"
+  font "MesloLGS NF Bold.ttf"
+  font "MesloLGS NF Italic.ttf"
+  font "MesloLGS NF Regular.ttf"
+end

--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ brew update && brew upgrade
 ```zsh
 brew uninstall romkatv/powerlevel10k/powerlevel10k
 ```
+
+## Install Meslo Nerd Font patched for Powerlevel10k
+
+```zsh
+brew install romkatv/powerlevel10k/font-powerlevel10k-meslo-lgs-nf
+```
+
+## Uninstall Meslo Nerd Font patched for Powerlevel10k
+
+```zsh
+brew uninstall romkatv/powerlevel10k/font-powerlevel10k-meslo-lgs-nf
+```


### PR DESCRIPTION
Proof-of-concept for installing Meslo Nerd Font patched for Powerlevel10k via Homebrew.

For this to work, a release must be created on https://github.com/romkatv/powerlevel10k-media.

For this test I created a release at my fork using CalVer based on the date you added the License file: https://github.com/thecesrom/powerlevel10k-media/releases/tag/v2020.4.15. I created a ZIP file only for the fonts and the license, and attached it as a binary for that release.

Local testing on my machine after creating the Cask:

```bash
$ export HOMEBREW_NO_AUTO_UPDATE=1
$ cp -R ./Casks /usr/local/Homebrew/Library/Taps/romkatv/homebrew-powerlevel10k
```

Install:

```bash
$ brew install romkatv/powerlevel10k/font-powerlevel10k-meslo-lgs-nf 
==> Downloading https://github.com/thecesrom/powerlevel10k-media/releases/download/v2020.4.15/MesloLGS-NF.zip
==> Installing Cask font-powerlevel10k-meslo-lgs-nf
==> Moving Font 'MesloLGS NF Bold Italic.ttf' to '/Users/thecesrom/Library/Fonts/MesloLGS NF Bold Italic.ttf'
==> Moving Font 'MesloLGS NF Bold.ttf' to '/Users/thecesrom/Library/Fonts/MesloLGS NF Bold.ttf'
==> Moving Font 'MesloLGS NF Italic.ttf' to '/Users/thecesrom/Library/Fonts/MesloLGS NF Italic.ttf'
==> Moving Font 'MesloLGS NF Regular.ttf' to '/Users/thecesrom/Library/Fonts/MesloLGS NF Regular.ttf'
🍺  font-powerlevel10k-meslo-lgs-nf was successfully installed!
```

Uninstall and cleanup:

```bash
$ brew uninstall romkatv/powerlevel10k/font-powerlevel10k-meslo-lgs-nf         
==> Uninstalling Cask font-powerlevel10k-meslo-lgs-nf
==> Backing Font 'MesloLGS NF Bold Italic.ttf' up to '/usr/local/Caskroom/font-powerlevel10k-meslo-lgs-nf/2020.4.15/MesloLGS NF Bold Italic.ttf'
==> Removing Font '/Users/thecesrom/Library/Fonts/MesloLGS NF Bold Italic.ttf'
==> Backing Font 'MesloLGS NF Bold.ttf' up to '/usr/local/Caskroom/font-powerlevel10k-meslo-lgs-nf/2020.4.15/MesloLGS NF Bold.ttf'
==> Removing Font '/Users/thecesrom/Library/Fonts/MesloLGS NF Bold.ttf'
==> Backing Font 'MesloLGS NF Italic.ttf' up to '/usr/local/Caskroom/font-powerlevel10k-meslo-lgs-nf/2020.4.15/MesloLGS NF Italic.ttf'
==> Removing Font '/Users/thecesrom/Library/Fonts/MesloLGS NF Italic.ttf'
==> Backing Font 'MesloLGS NF Regular.ttf' up to '/usr/local/Caskroom/font-powerlevel10k-meslo-lgs-nf/2020.4.15/MesloLGS NF Regular.ttf'
==> Removing Font '/Users/thecesrom/Library/Fonts/MesloLGS NF Regular.ttf'
==> Purging files for version 2020.4.15 of Cask font-powerlevel10k-meslo-lgs-nf
$ unset HOMEBREW_NO_AUTO_UPDATE
```

- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew livecheck <cask>` reports the correct version.

```bash
$ brew audit --cask font-powerlevel10k-meslo-lgs-nf 
audit for font-powerlevel10k-meslo-lgs-nf: passed
$ brew style --fix font-powerlevel10k-meslo-lgs-nf

1 file inspected, no offenses detected
$ brew livecheck font-powerlevel10k-meslo-lgs-nf  
font-powerlevel10k-meslo-lgs-nf : 2020.4.15 ==> 2020.4.15
```