### PR TITLE
Fix path to source for Homebrew on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is the official Homebrew Tap for
 
 ```zsh
 brew install romkatv/powerlevel10k/powerlevel10k
-echo 'source /usr/local/opt/powerlevel10k/powerlevel10k.zsh-theme' >>! ~/.zshrc
+echo 'source $(brew --prefix powerlevel10k)/powerlevel10k.zsh-theme' >>! ~/.zshrc
 ```
 
 ## Update Powerlevel10k with Homebrew


### PR DESCRIPTION
The installation path of Homebrew packages is different on Linux.
Use the `brew --prefix powerlevel10k` command so the theme
location is correct regardless of installation prefix.
